### PR TITLE
feat: Climate platform + operating mode (Betriebsart) select

### DIFF
--- a/custom_components/dimplex/__init__.py
+++ b/custom_components/dimplex/__init__.py
@@ -19,6 +19,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.SELECT,
+    Platform.CLIMATE,
 ]
 
 

--- a/custom_components/dimplex/climate.py
+++ b/custom_components/dimplex/climate.py
@@ -1,0 +1,113 @@
+"""Climate platform for Dimplex integration."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, VarID
+from .coordinator import DimplexCoordinator
+
+# Map the live status register (WP_STATUS_1 / 1586i) to what the pump is
+# currently doing. The operating mode itself (Betriebsart) is exposed as a
+# separate select entity, so this entity only reports the live action.
+STATUS_VALUE_TO_ACTION: dict[str, HVACAction] = {
+    "2": HVACAction.HEATING,    # Heizen
+    "3": HVACAction.HEATING,    # Schwimmbad
+    "4": HVACAction.IDLE,       # Warmwasser (no dedicated HA action)
+    "5": HVACAction.COOLING,    # Kühlen
+    "10": HVACAction.DEFROSTING,  # Abtauen
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Dimplex climate entities."""
+    coordinator: DimplexCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([DimplexClimate(coordinator)])
+
+
+class DimplexClimate(CoordinatorEntity[DimplexCoordinator], ClimateEntity):
+    """Heat pump climate entity for room temperature control (heating circuit 1).
+
+    Target/current temperature use the base room setpoint (502a, a plain degC
+    float) and the actual room temperature (1632i) rather than the
+    heating-curve-derived flow values (1620i/1621i), which are recomputed and
+    cannot be set directly. The operating mode (Betriebsart) is handled by a
+    dedicated select entity, so this entity only exposes temperature plus the
+    current activity via ``hvac_action``.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "heat_pump"
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+    # Mode selection lives in the Betriebsart select; keep a single neutral mode
+    # here so the card never shows a misleading "Off" (Sommer still does hot water).
+    _attr_hvac_modes = [HVACMode.AUTO]
+    _attr_hvac_mode = HVACMode.AUTO
+    _attr_min_temp = 10.0
+    _attr_max_temp = 30.0
+    _attr_target_temperature_step = 0.1
+
+    def __init__(self, coordinator: DimplexCoordinator) -> None:
+        """Initialize the climate entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.client.device_id}_climate"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, coordinator.client.device_id)},
+            "name": "Dimplex Heat Pump",
+            "manufacturer": "Dimplex",
+            "model": "Heat Pump",
+        }
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current room temperature."""
+        return self.coordinator.get_value(VarID.ROOM_TEMP_HK1, scale=0.1)
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the room temperature setpoint (502a is a plain degC float)."""
+        value = self.coordinator.get_value(VarID.ROOM_SETPOINT_HK1)
+        try:
+            return float(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return what the heat pump is currently doing."""
+        status = self.coordinator.get_value(VarID.WP_STATUS_1)
+        if status is None:
+            return None
+        return STATUS_VALUE_TO_ACTION.get(str(status), HVACAction.IDLE)
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set a new room temperature setpoint."""
+        if (temp := kwargs.get(ATTR_TEMPERATURE)) is None:
+            return
+
+        # 502a is a plain degC float (0.1 resolution) - write it directly.
+        api_value = round(float(temp), 1)
+        await self.coordinator.client.write_variable(
+            VarID.ROOM_SETPOINT_HK1, api_value
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """No-op: the operating mode is controlled via the Betriebsart select."""
+        return

--- a/custom_components/dimplex/const.py
+++ b/custom_components/dimplex/const.py
@@ -29,7 +29,7 @@ CONF_DEVICE_ID: Final = "device_id"
 CONF_ACCESS_TOKEN: Final = "access_token"
 CONF_REFRESH_TOKEN: Final = "refresh_token"
 
-# Variable IDs from reverse engineering
+# Variable IDs
 class VarID:
     """Variable IDs for Dimplex API."""
     # Bypass & Ventilation Control (writable)
@@ -74,6 +74,14 @@ class VarID:
     COMPRESSOR_CLOCKS_HOTWATER: Final = "1493i"
     COMPRESSOR_CLOCKS_COOLING: Final = "1495i"
     
+    # Climate control (room-regulated heating circuit 1)
+    # 502a is the base room setpoint (a plain degC float). Note 1629i is the
+    # EFFECTIVE setpoint = 502a + room-regulation raise (816i), so it reads
+    # higher and must not be used as the writable setpoint.
+    ROOM_SETPOINT_HK1: Final = "502a"
+    ROOM_TEMP_HK1: Final = "1632i"  # Hk1_Raum_Temp - actual room temperature (x0.1)
+    OPERATING_MODE: Final = "714i"  # BA_aktiv - persistent operating mode (Betriebsart)
+
     # Status
     SMARTGRID: Final = "1246d"
     WP_STATUS_1: Final = "1586i"
@@ -119,6 +127,8 @@ ALL_VARIABLE_IDS: Final = [
     VarID.WP_STATUS_1,
     VarID.WP_STATUS_2,
     VarID.COMPRESSOR_SPEED,
+    VarID.ROOM_TEMP_HK1,
+    VarID.OPERATING_MODE,
 ]
 
 # Status mappings
@@ -133,6 +143,21 @@ WP_STATUS_2_MAP: Final = {
     "0": "Off",
     "1": "Active",
 }
+
+# Operating mode (Betriebsart, 714i) - the persistent operating mode.
+# Distinct from WP_STATUS_1 (1586i), which is the current live status.
+OPERATING_MODE_MAP: Final = {
+    "0": "Sommer (nur Warmwasser)",
+    "1": "Winter",
+    "2": "Urlaub",
+    "3": "Party",
+    "4": "2. Wärmeerzeuger",
+    "5": "Kühlen",
+    "6": "Auto",
+}
+
+# Reverse mapping for setting the operating mode
+OPERATING_MODE_TO_VALUE: Final = {v: k for k, v in OPERATING_MODE_MAP.items()}
 
 VENTILATION_MODE_MAP: Final = {
     "0": "Off",

--- a/custom_components/dimplex/select.py
+++ b/custom_components/dimplex/select.py
@@ -13,6 +13,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import (
     DOMAIN,
     VarID,
+    OPERATING_MODE_MAP,
+    OPERATING_MODE_TO_VALUE,
     VENTILATION_MODE_MAP,
     VENTILATION_MODE_TO_VALUE,
 )
@@ -31,7 +33,48 @@ async def async_setup_entry(
 
     async_add_entities([
         DimplexVentilationModeSelect(coordinator),
+        DimplexOperatingModeSelect(coordinator),
     ])
+
+
+class DimplexOperatingModeSelect(CoordinatorEntity[DimplexCoordinator], SelectEntity):
+    """Representation of the Dimplex operating mode (Betriebsart) selector."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "operating_mode"
+    _attr_icon = "mdi:sun-snowflake-variant"
+    _attr_options = list(OPERATING_MODE_MAP.values())
+
+    def __init__(self, coordinator: DimplexCoordinator) -> None:
+        """Initialize the select entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.client.device_id}_operating_mode_select"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, coordinator.client.device_id)},
+            "name": "Dimplex Heat Pump",
+            "manufacturer": "Dimplex",
+            "model": "Heat Pump",
+        }
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current operating mode."""
+        return self.coordinator.get_mapped_value(
+            VarID.OPERATING_MODE,
+            OPERATING_MODE_MAP,
+            default=None,
+        )
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the operating mode."""
+        if option not in OPERATING_MODE_TO_VALUE:
+            _LOGGER.error("Invalid operating mode: %s", option)
+            return
+
+        value = int(OPERATING_MODE_TO_VALUE[option])
+        _LOGGER.debug("Setting operating mode to %s (value: %d)", option, value)
+        await self.coordinator.client.write_variable(VarID.OPERATING_MODE, value)
+        await self.coordinator.async_request_refresh()
 
 
 class DimplexVentilationModeSelect(CoordinatorEntity[DimplexCoordinator], SelectEntity):

--- a/custom_components/dimplex/strings.json
+++ b/custom_components/dimplex/strings.json
@@ -75,5 +75,17 @@
       "already_configured": "Device already configured",
       "reauth_successful": "Authentication successful"
     }
+  },
+  "entity": {
+    "climate": {
+      "heat_pump": {
+        "name": "Heat Pump"
+      }
+    },
+    "select": {
+      "operating_mode": {
+        "name": "Operating Mode"
+      }
+    }
   }
 }

--- a/custom_components/dimplex/translations/de.json
+++ b/custom_components/dimplex/translations/de.json
@@ -77,6 +77,11 @@
     }
   },
   "entity": {
+    "climate": {
+      "heat_pump": {
+        "name": "Wärmepumpe"
+      }
+    },
     "sensor": {
       "temperature_warmwater": {
         "name": "Warmwasser Temperatur"
@@ -186,6 +191,9 @@
     "select": {
       "ventilation_mode": {
         "name": "Lüftungsstufe"
+      },
+      "operating_mode": {
+        "name": "Betriebsart"
       }
     }
   }

--- a/custom_components/dimplex/translations/en.json
+++ b/custom_components/dimplex/translations/en.json
@@ -77,6 +77,11 @@
     }
   },
   "entity": {
+    "climate": {
+      "heat_pump": {
+        "name": "Heat Pump"
+      }
+    },
     "sensor": {
       "temperature_warmwater": {
         "name": "Hot Water Temperature"
@@ -186,6 +191,9 @@
     "select": {
       "ventilation_mode": {
         "name": "Ventilation Level"
+      },
+      "operating_mode": {
+        "name": "Operating Mode"
       }
     }
   }


### PR DESCRIPTION
## Climate platform + operating mode (Betriebsart)

Adds a thermostat (climate) entity and a separate operating-mode select. Register behaviour was verified on real hardware.

### Climate entity
- **Target temperature** → `502a` (base room setpoint, a plain °C float). It tracks the value set on the device 1:1.
  - Note: `1629i` is the *effective* setpoint = base + room-regulation raise (`816i`), so it reads ~2 K higher and is intentionally **not** used.
- **Current temperature** → `1632i` (actual room temperature).
- **hvac_action** → derived from the live status register `1586i` (heating / cooling / defrosting / idle).
- No HVAC-mode writing: the mode is handled by the select below, so the card never shows a misleading "Off" (Sommer = hot water only).

### Operating mode select (Betriebsart)
- `714i` with the full set of states: Sommer (nur Warmwasser), Winter, Urlaub, Party, 2. Wärmeerzeuger, Kühlen, Auto.
- This is the persistent operating mode, distinct from `1586i` (current live status).

### Notes
- The earlier climate draft wrote the mode to the status register `1586i` and used the heating-curve display values `1620i`/`1621i` for temperature, which are recomputed by the controller and can't be set directly. This PR uses the registers that actually take a write.
- Tested on real hardware (read + write).
