### PR TITLE
feat: Thermal energy / heat-meter sensors

### DIFF
--- a/custom_components/dimplex/const.py
+++ b/custom_components/dimplex/const.py
@@ -82,6 +82,26 @@ class VarID:
     ROOM_TEMP_HK1: Final = "1632i"  # Hk1_Raum_Temp - actual room temperature (x0.1)
     OPERATING_MODE: Final = "714i"  # BA_aktiv - persistent operating mode (Betriebsart)
 
+    # Heat/energy meters (thermal kWh). Each counter is split across a low word
+    # (0-9999) and a high word (x10000 steps): value = high * 10000 + low.
+    HEAT_TOTAL_LOW: Final = "1660i"        # heat pump total (heating + hot water)
+    HEAT_TOTAL_HIGH: Final = "1661i"
+    HEAT_HEATING_LOW: Final = "1663i"      # heating
+    HEAT_HEATING_HIGH: Final = "1664i"
+    HEAT_HOTWATER_LOW: Final = "1669i"     # hot water
+    HEAT_HOTWATER_HIGH: Final = "1670i"
+    ENV_ENERGY_LOW: Final = "1644i"        # environmental (ambient) energy
+    ENV_ENERGY_HIGH: Final = "1645i"
+    # Resettable counterparts of the above
+    HEAT_TOTAL_RES_LOW: Final = "1672i"
+    HEAT_TOTAL_RES_HIGH: Final = "1673i"
+    HEAT_HEATING_RES_LOW: Final = "1675i"
+    HEAT_HEATING_RES_HIGH: Final = "1676i"
+    HEAT_HOTWATER_RES_LOW: Final = "1681i"
+    HEAT_HOTWATER_RES_HIGH: Final = "1682i"
+    ENV_ENERGY_RES_LOW: Final = "1647i"
+    ENV_ENERGY_RES_HIGH: Final = "1648i"
+
     # Status
     SMARTGRID: Final = "1246d"
     WP_STATUS_1: Final = "1586i"
@@ -129,6 +149,22 @@ ALL_VARIABLE_IDS: Final = [
     VarID.COMPRESSOR_SPEED,
     VarID.ROOM_TEMP_HK1,
     VarID.OPERATING_MODE,
+    VarID.HEAT_TOTAL_LOW,
+    VarID.HEAT_TOTAL_HIGH,
+    VarID.HEAT_HEATING_LOW,
+    VarID.HEAT_HEATING_HIGH,
+    VarID.HEAT_HOTWATER_LOW,
+    VarID.HEAT_HOTWATER_HIGH,
+    VarID.ENV_ENERGY_LOW,
+    VarID.ENV_ENERGY_HIGH,
+    VarID.HEAT_TOTAL_RES_LOW,
+    VarID.HEAT_TOTAL_RES_HIGH,
+    VarID.HEAT_HEATING_RES_LOW,
+    VarID.HEAT_HEATING_RES_HIGH,
+    VarID.HEAT_HOTWATER_RES_LOW,
+    VarID.HEAT_HOTWATER_RES_HIGH,
+    VarID.ENV_ENERGY_RES_LOW,
+    VarID.ENV_ENERGY_RES_HIGH,
 ]
 
 # Status mappings

--- a/custom_components/dimplex/coordinator.py
+++ b/custom_components/dimplex/coordinator.py
@@ -96,6 +96,40 @@ class DimplexCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             return default
 
+    def get_combined_value(
+        self,
+        low_variable_id: str,
+        high_variable_id: str,
+        scale: float = 1.0,
+        default: Any = None,
+    ) -> Any:
+        """Return a counter split across a low word (0-9999) and a high word.
+
+        Some energy/heat meters store the value across two registers: a low
+        word counting 0-9999 and a separate high word counting the x10000
+        steps. The real value is ``high * 10000 + low``. A missing high word is
+        treated as 0, so it stays correct for counters still below 10000.
+        """
+        low = self.get_value(low_variable_id)
+        if low is None:
+            return default
+
+        high = self.get_value(high_variable_id) or 0
+        try:
+            combined = int(high) * 10000 + int(low)
+        except (TypeError, ValueError) as err:
+            _LOGGER.debug(
+                "Error combining values for %s/%s: %s",
+                low_variable_id,
+                high_variable_id,
+                err,
+            )
+            return default
+
+        if scale != 1.0:
+            return combined * scale
+        return combined
+
     def get_mapped_value(
         self,
         variable_id: str,

--- a/custom_components/dimplex/sensor.py
+++ b/custom_components/dimplex/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
+    UnitOfEnergy,
     UnitOfTemperature,
     UnitOfTime,
     UnitOfVolumeFlowRate,
@@ -40,6 +41,9 @@ class DimplexSensorEntityDescription(SensorEntityDescription):
     variable_id: str
     scale: float = 1.0
     value_map: dict[str, str] | None = None
+    # When set, the value is combined from a low word (variable_id) and this
+    # high word: value = high * 10000 + low (see coordinator.get_combined_value).
+    high_variable_id: str | None = None
 
 
 SENSOR_DESCRIPTIONS: tuple[DimplexSensorEntityDescription, ...] = (
@@ -280,6 +284,77 @@ SENSOR_DESCRIPTIONS: tuple[DimplexSensorEntityDescription, ...] = (
         variable_id=VarID.VENT_BYPASS_STATUS,
         icon="mdi:valve",
     ),
+    # Heat/energy meters (thermal kWh, combined from low/high register pairs)
+    DimplexSensorEntityDescription(
+        key="heat_total",
+        variable_id=VarID.HEAT_TOTAL_LOW,
+        high_variable_id=VarID.HEAT_TOTAL_HIGH,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    DimplexSensorEntityDescription(
+        key="heat_heating",
+        variable_id=VarID.HEAT_HEATING_LOW,
+        high_variable_id=VarID.HEAT_HEATING_HIGH,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    DimplexSensorEntityDescription(
+        key="heat_hotwater",
+        variable_id=VarID.HEAT_HOTWATER_LOW,
+        high_variable_id=VarID.HEAT_HOTWATER_HIGH,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    DimplexSensorEntityDescription(
+        key="environmental_energy",
+        variable_id=VarID.ENV_ENERGY_LOW,
+        high_variable_id=VarID.ENV_ENERGY_HIGH,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    # Resettable counterparts (disabled by default to avoid Energy Dashboard
+    # confusion; total_increasing handles the resets if you enable them).
+    DimplexSensorEntityDescription(
+        key="heat_total_resettable",
+        variable_id=VarID.HEAT_TOTAL_RES_LOW,
+        high_variable_id=VarID.HEAT_TOTAL_RES_HIGH,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
+    ),
+    DimplexSensorEntityDescription(
+        key="heat_heating_resettable",
+        variable_id=VarID.HEAT_HEATING_RES_LOW,
+        high_variable_id=VarID.HEAT_HEATING_RES_HIGH,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
+    ),
+    DimplexSensorEntityDescription(
+        key="heat_hotwater_resettable",
+        variable_id=VarID.HEAT_HOTWATER_RES_LOW,
+        high_variable_id=VarID.HEAT_HOTWATER_RES_HIGH,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
+    ),
+    DimplexSensorEntityDescription(
+        key="environmental_energy_resettable",
+        variable_id=VarID.ENV_ENERGY_RES_LOW,
+        high_variable_id=VarID.ENV_ENERGY_RES_HIGH,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
+    ),
 )
 
 
@@ -329,6 +404,13 @@ class DimplexSensor(CoordinatorEntity[DimplexCoordinator], SensorEntity):
             return self.coordinator.get_mapped_value(
                 desc.variable_id,
                 desc.value_map,
+            )
+
+        if desc.high_variable_id:
+            return self.coordinator.get_combined_value(
+                desc.variable_id,
+                desc.high_variable_id,
+                scale=desc.scale,
             )
 
         return self.coordinator.get_value(

--- a/custom_components/dimplex/strings.json
+++ b/custom_components/dimplex/strings.json
@@ -86,6 +86,32 @@
       "operating_mode": {
         "name": "Operating Mode"
       }
+    },
+    "sensor": {
+      "heat_total": {
+        "name": "Total Heat Output"
+      },
+      "heat_heating": {
+        "name": "Heating Energy"
+      },
+      "heat_hotwater": {
+        "name": "Hot Water Energy"
+      },
+      "environmental_energy": {
+        "name": "Environmental Energy"
+      },
+      "heat_total_resettable": {
+        "name": "Total Heat Output (resettable)"
+      },
+      "heat_heating_resettable": {
+        "name": "Heating Energy (resettable)"
+      },
+      "heat_hotwater_resettable": {
+        "name": "Hot Water Energy (resettable)"
+      },
+      "environmental_energy_resettable": {
+        "name": "Environmental Energy (resettable)"
+      }
     }
   }
 }

--- a/custom_components/dimplex/translations/de.json
+++ b/custom_components/dimplex/translations/de.json
@@ -181,6 +181,30 @@
       },
       "ventilation_bypass": {
         "name": "Bypass Status"
+      },
+      "heat_total": {
+        "name": "Wärmemenge gesamt"
+      },
+      "heat_heating": {
+        "name": "Wärmemenge Heizen"
+      },
+      "heat_hotwater": {
+        "name": "Wärmemenge Warmwasser"
+      },
+      "environmental_energy": {
+        "name": "Umweltenergie"
+      },
+      "heat_total_resettable": {
+        "name": "Wärmemenge gesamt (rücksetzbar)"
+      },
+      "heat_heating_resettable": {
+        "name": "Wärmemenge Heizen (rücksetzbar)"
+      },
+      "heat_hotwater_resettable": {
+        "name": "Wärmemenge Warmwasser (rücksetzbar)"
+      },
+      "environmental_energy_resettable": {
+        "name": "Umweltenergie (rücksetzbar)"
       }
     },
     "switch": {

--- a/custom_components/dimplex/translations/en.json
+++ b/custom_components/dimplex/translations/en.json
@@ -181,6 +181,30 @@
       },
       "ventilation_bypass": {
         "name": "Bypass Status"
+      },
+      "heat_total": {
+        "name": "Total Heat Output"
+      },
+      "heat_heating": {
+        "name": "Heating Energy"
+      },
+      "heat_hotwater": {
+        "name": "Hot Water Energy"
+      },
+      "environmental_energy": {
+        "name": "Environmental Energy"
+      },
+      "heat_total_resettable": {
+        "name": "Total Heat Output (resettable)"
+      },
+      "heat_heating_resettable": {
+        "name": "Heating Energy (resettable)"
+      },
+      "heat_hotwater_resettable": {
+        "name": "Hot Water Energy (resettable)"
+      },
+      "environmental_energy_resettable": {
+        "name": "Environmental Energy (resettable)"
       }
     },
     "switch": {


### PR DESCRIPTION
## Thermal energy / heat-meter sensors

Adds heat-quantity sensors (thermal **kWh**, `state_class: total_increasing`, `device_class: energy`):

- **Total Heat Output** (`1660i`/`1661i`)
- **Heating Energy** (`1663i`/`1664i`)
- **Hot Water Energy** (`1669i`/`1670i`)
- **Environmental Energy** (`1644i`/`1645i`)

Plus resettable counterparts, **disabled by default**.

### Low/high counter pairing
Each counter is split across a **low word (0–9999)** and a **high word (×10000)** — the real value is `high * 10000 + low`. Reading a single register wraps/undercounts once a counter passes 9999. Combined via a new `coordinator.get_combined_value()` helper (a missing high word is treated as 0, so it stays correct for counters still below 10000).

The low/high combination approach was contributed by @tsgoff in #3 — thanks! This PR wires it up with register pairs verified on the device against the displayed totals (e.g. `1*10000 + 8608 = 18608 kWh`).
