### PR TITLE
feat: Hot water (water_heater) control

### DIFF
--- a/custom_components/dimplex/__init__.py
+++ b/custom_components/dimplex/__init__.py
@@ -20,6 +20,7 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.SELECT,
     Platform.CLIMATE,
+    Platform.WATER_HEATER,
 ]
 
 

--- a/custom_components/dimplex/const.py
+++ b/custom_components/dimplex/const.py
@@ -74,6 +74,10 @@ class VarID:
     COMPRESSOR_CLOCKS_HOTWATER: Final = "1493i"
     COMPRESSOR_CLOCKS_COOLING: Final = "1495i"
     
+    # Hot water
+    WW_SETPOINT: Final = "1042i"   # P_WW_SOLL - hot water setpoint (degC)
+    WW_BLOCK_EXT: Final = "771d"   # WW_Sp_Ext - external hot water block
+
     # Climate control (room-regulated heating circuit 1)
     # 502a is the base room setpoint (a plain degC float). Note 1629i is the
     # EFFECTIVE setpoint = 502a + room-regulation raise (816i), so it reads
@@ -165,6 +169,8 @@ ALL_VARIABLE_IDS: Final = [
     VarID.HEAT_HOTWATER_RES_HIGH,
     VarID.ENV_ENERGY_RES_LOW,
     VarID.ENV_ENERGY_RES_HIGH,
+    VarID.WW_SETPOINT,
+    VarID.WW_BLOCK_EXT,
 ]
 
 # Status mappings

--- a/custom_components/dimplex/const.py
+++ b/custom_components/dimplex/const.py
@@ -75,8 +75,10 @@ class VarID:
     COMPRESSOR_CLOCKS_COOLING: Final = "1495i"
     
     # Hot water
-    WW_SETPOINT: Final = "1042i"   # P_WW_SOLL - hot water setpoint (degC)
-    WW_BLOCK_EXT: Final = "771d"   # WW_Sp_Ext - external hot water block
+    WW_SETPOINT: Final = "1042i"        # P_WW_SOLL - hot water setpoint (degC)
+    WW_BLOCK_EXT: Final = "771d"        # WW_Sp_Ext - external hot water block
+    WW_REQUEST_STATUS: Final = "1592i"  # Anz_Anf_Ww - request/block status
+    WW_ACTIVE: Final = "1482d"          # c_WW_aktiv - hot water currently active
 
     # Climate control (room-regulated heating circuit 1)
     # 502a is the base room setpoint (a plain degC float). Note 1629i is the
@@ -171,6 +173,8 @@ ALL_VARIABLE_IDS: Final = [
     VarID.ENV_ENERGY_RES_HIGH,
     VarID.WW_SETPOINT,
     VarID.WW_BLOCK_EXT,
+    VarID.WW_REQUEST_STATUS,
+    VarID.WW_ACTIVE,
 ]
 
 # Status mappings
@@ -200,6 +204,17 @@ OPERATING_MODE_MAP: Final = {
 
 # Reverse mapping for setting the operating mode
 OPERATING_MODE_TO_VALUE: Final = {v: k for k, v in OPERATING_MODE_MAP.items()}
+
+WW_REQUEST_STATUS_MAP: Final = {
+    "0": "No request",
+    "1": "Request",
+    "2": "Blocked",
+}
+
+WW_ACTIVE_MAP: Final = {
+    "0": "Off",
+    "1": "On",
+}
 
 VENTILATION_MODE_MAP: Final = {
     "0": "Off",

--- a/custom_components/dimplex/sensor.py
+++ b/custom_components/dimplex/sensor.py
@@ -30,6 +30,8 @@ from .const import (
     WP_STATUS_1_MAP,
     WP_STATUS_2_MAP,
     VENTILATION_MODE_MAP,
+    WW_REQUEST_STATUS_MAP,
+    WW_ACTIVE_MAP,
 )
 from .coordinator import DimplexCoordinator
 
@@ -354,6 +356,19 @@ SENSOR_DESCRIPTIONS: tuple[DimplexSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_registry_enabled_default=False,
+    ),
+    # Hot water status
+    DimplexSensorEntityDescription(
+        key="hot_water_status",
+        variable_id=VarID.WW_REQUEST_STATUS,
+        value_map=WW_REQUEST_STATUS_MAP,
+        icon="mdi:water-boiler",
+    ),
+    DimplexSensorEntityDescription(
+        key="hot_water_active",
+        variable_id=VarID.WW_ACTIVE,
+        value_map=WW_ACTIVE_MAP,
+        icon="mdi:water-boiler",
     ),
 )
 

--- a/custom_components/dimplex/strings.json
+++ b/custom_components/dimplex/strings.json
@@ -115,7 +115,11 @@
     },
     "water_heater": {
       "hot_water": {
-        "name": "Hot Water"
+        "name": "Hot Water",
+        "state": {
+          "heat_pump": "Normal",
+          "off": "Blocked"
+        }
       }
     }
   }

--- a/custom_components/dimplex/strings.json
+++ b/custom_components/dimplex/strings.json
@@ -112,6 +112,11 @@
       "environmental_energy_resettable": {
         "name": "Environmental Energy (resettable)"
       }
+    },
+    "water_heater": {
+      "hot_water": {
+        "name": "Hot Water"
+      }
     }
   }
 }

--- a/custom_components/dimplex/strings.json
+++ b/custom_components/dimplex/strings.json
@@ -111,6 +111,12 @@
       },
       "environmental_energy_resettable": {
         "name": "Environmental Energy (resettable)"
+      },
+      "hot_water_status": {
+        "name": "Hot Water Status"
+      },
+      "hot_water_active": {
+        "name": "Hot Water Active"
       }
     },
     "water_heater": {

--- a/custom_components/dimplex/translations/de.json
+++ b/custom_components/dimplex/translations/de.json
@@ -205,6 +205,12 @@
       },
       "environmental_energy_resettable": {
         "name": "Umweltenergie (rücksetzbar)"
+      },
+      "hot_water_status": {
+        "name": "Warmwasser-Status"
+      },
+      "hot_water_active": {
+        "name": "Warmwasser aktiv"
       }
     },
     "switch": {

--- a/custom_components/dimplex/translations/de.json
+++ b/custom_components/dimplex/translations/de.json
@@ -219,6 +219,11 @@
       "operating_mode": {
         "name": "Betriebsart"
       }
+    },
+    "water_heater": {
+      "hot_water": {
+        "name": "Warmwasser"
+      }
     }
   }
 }

--- a/custom_components/dimplex/translations/de.json
+++ b/custom_components/dimplex/translations/de.json
@@ -222,7 +222,11 @@
     },
     "water_heater": {
       "hot_water": {
-        "name": "Warmwasser"
+        "name": "Warmwasser",
+        "state": {
+          "heat_pump": "Normal",
+          "off": "Gesperrt"
+        }
       }
     }
   }

--- a/custom_components/dimplex/translations/en.json
+++ b/custom_components/dimplex/translations/en.json
@@ -205,6 +205,12 @@
       },
       "environmental_energy_resettable": {
         "name": "Environmental Energy (resettable)"
+      },
+      "hot_water_status": {
+        "name": "Hot Water Status"
+      },
+      "hot_water_active": {
+        "name": "Hot Water Active"
       }
     },
     "switch": {

--- a/custom_components/dimplex/translations/en.json
+++ b/custom_components/dimplex/translations/en.json
@@ -222,7 +222,11 @@
     },
     "water_heater": {
       "hot_water": {
-        "name": "Hot Water"
+        "name": "Hot Water",
+        "state": {
+          "heat_pump": "Normal",
+          "off": "Blocked"
+        }
       }
     }
   }

--- a/custom_components/dimplex/translations/en.json
+++ b/custom_components/dimplex/translations/en.json
@@ -219,6 +219,11 @@
       "operating_mode": {
         "name": "Operating Mode"
       }
+    },
+    "water_heater": {
+      "hot_water": {
+        "name": "Hot Water"
+      }
     }
   }
 }

--- a/custom_components/dimplex/water_heater.py
+++ b/custom_components/dimplex/water_heater.py
@@ -52,6 +52,7 @@ class DimplexWaterHeater(CoordinatorEntity[DimplexCoordinator], WaterHeaterEntit
     _attr_operation_list = [OPERATION_ON, OPERATION_OFF]
     _attr_min_temp = 30.0
     _attr_max_temp = 65.0
+    _attr_target_temperature_step = 1.0  # the setpoint (1042i) is whole degrees
 
     def __init__(self, coordinator: DimplexCoordinator) -> None:
         """Initialize the water heater entity."""

--- a/custom_components/dimplex/water_heater.py
+++ b/custom_components/dimplex/water_heater.py
@@ -1,0 +1,104 @@
+"""Water heater platform for Dimplex integration."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.water_heater import (
+    STATE_HEAT_PUMP,
+    WaterHeaterEntity,
+    WaterHeaterEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, VarID
+from .coordinator import DimplexCoordinator
+
+# Operation modes map onto the external hot-water block (771d):
+#   "heat_pump" -> block off (hot water allowed)
+#   "off"       -> block on  (hot water suppressed)
+OPERATION_ON = STATE_HEAT_PUMP
+OPERATION_OFF = STATE_OFF
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Dimplex water heater entity."""
+    coordinator: DimplexCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([DimplexWaterHeater(coordinator)])
+
+
+class DimplexWaterHeater(CoordinatorEntity[DimplexCoordinator], WaterHeaterEntity):
+    """Hot water control for the Dimplex heat pump.
+
+    Exposes the current hot-water temperature (1305a) and the writable hot-water
+    setpoint (1042i). The on/off operation maps onto the external hot-water block
+    (771d), which can be used to suppress hot water during expensive hours.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "hot_water"
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_supported_features = (
+        WaterHeaterEntityFeature.TARGET_TEMPERATURE
+        | WaterHeaterEntityFeature.OPERATION_MODE
+    )
+    _attr_operation_list = [OPERATION_ON, OPERATION_OFF]
+    _attr_min_temp = 30.0
+    _attr_max_temp = 65.0
+
+    def __init__(self, coordinator: DimplexCoordinator) -> None:
+        """Initialize the water heater entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.client.device_id}_hot_water"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, coordinator.client.device_id)},
+            "name": "Dimplex Heat Pump",
+            "manufacturer": "Dimplex",
+            "model": "Heat Pump",
+        }
+
+    @staticmethod
+    def _to_float(value: Any) -> float | None:
+        try:
+            return float(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current hot water temperature."""
+        return self._to_float(self.coordinator.get_value(VarID.TEMP_WARMWATER))
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the hot water setpoint."""
+        return self._to_float(self.coordinator.get_value(VarID.WW_SETPOINT))
+
+    @property
+    def current_operation(self) -> str:
+        """Return whether hot water is currently allowed or blocked."""
+        blocked = self.coordinator.get_value(VarID.WW_BLOCK_EXT)
+        return OPERATION_OFF if str(blocked) == "1" else OPERATION_ON
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set a new hot water setpoint."""
+        if (temp := kwargs.get(ATTR_TEMPERATURE)) is None:
+            return
+
+        await self.coordinator.client.write_variable(
+            VarID.WW_SETPOINT, int(round(temp))
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_operation_mode(self, operation_mode: str) -> None:
+        """Allow or block hot water via the external block flag."""
+        value = 1 if operation_mode == OPERATION_OFF else 0
+        await self.coordinator.client.write_variable(VarID.WW_BLOCK_EXT, value)
+        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
## Hot water control (`water_heater`)

Adds a `water_heater` entity for the domestic hot water:

- **Current temperature** → `1305a` (already read as a sensor)
- **Target temperature** → `1042i` (read **and set**, 30–65 °C)
- **Operation on/off** → maps onto the external hot-water block `771d` (`heat_pump` = allowed, `off` = blocked)

This gives a proper hot-water card and enables price-based load shifting: lower the setpoint / set "off" during expensive hours, raise / "on" during cheap hours.

### Notes
- `771d` (external block) is confirmed writable on the device. Setting the target (`1042i`) and the operation mode should be verified on hardware (an `i`-type setpoint like the already-working room setpoint, so expected to take).
